### PR TITLE
Changes from background agent bc-0aa18f61-b9ff-4a8e-983a-3aa4a79d230c

### DIFF
--- a/GETASSOCIATEDPRODUCTSWITHORDERLIST.sql
+++ b/GETASSOCIATEDPRODUCTSWITHORDERLIST.sql
@@ -1577,8 +1577,7 @@ BEGIN
      ORDER BY C.SERIALNUMBER DESC            
                     FOR     XML AUTO ,            
                                 ELEMENTS          
-   RETURN                
-   END              
+                END              
         END                  
                                   
     IF @ORDERNAME = 'SERIALNUMBER'            


### PR DESCRIPTION
Remove misplaced `RETURN` statement to fix syntax error in `GETASSOCIATEDPRODUCTSWITHORDERLIST` stored procedure.

The `RETURN` statement was incorrectly placed after a `FOR XML AUTO, ELEMENTS` clause, leading to an "incorrect syntax near ELEMENTS" error. Removing it resolves the compilation issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-0aa18f61-b9ff-4a8e-983a-3aa4a79d230c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0aa18f61-b9ff-4a8e-983a-3aa4a79d230c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

